### PR TITLE
Update truck starting locations and diversify daily delivery routes

### DIFF
--- a/ICA2SYC/src/ICA2.clj
+++ b/ICA2SYC/src/ICA2.clj
@@ -23,14 +23,17 @@
    :prague  [[:warsaw 500] [:krakow 600] [:hamburg 300] [:munich 300] [:brno 100] [:berlin 200]]
    :berlin  [[:warsaw 300] [:krakow 400] [:hamburg 100] [:munich 100] [:brno 300] [:prague 200]]})
 
+
 (def trucks
   (atom {:truck1 {:capacity 50 :load 0 :location :warsaw}
-         :truck2 {:capacity 50 :load 0 :location :warsaw}}))
+         :truck2 {:capacity 50 :load 0 :location :berlin}}))
+
 
 (def daily-routes
-  {1 [[:warsaw :brno 50] [:warsaw :krakow 20]]
-   2 [[:warsaw :prague 15]]
-   3 [[:warsaw :hamburg 40]]})
+  {1 [[:berlin :brno 50] [:warsaw :krakow 20]]
+   2 [[:brno :prague 15]]
+   3 [[:berlin :hamburg 40]]})
+
 
 ;; ---------------------------------------------------------
 ;; 2. Function A-star for getting the shortest route


### PR DESCRIPTION
Updated the initial location of truck2 from :warsaw to :berlin to improve delivery efficiency.
Modified daily routes:
Day 1: Added a delivery from :berlin to :brno.
Day 3: Changed the delivery from :warsaw to :hamburg to :berlin to :hamburg.
These changes balance delivery responsibilities and reduce the reliance on :warsaw as the primary starting point.