### PR TITLE
Enhance truck selection logic in pick-truck function

### DIFF
--- a/ICA2SYC/src/ICA2.clj
+++ b/ICA2SYC/src/ICA2.clj
@@ -65,14 +65,26 @@
   (let [valid-trucks
         (filter (fn [[tid {:keys [capacity load location]}]]
                   (and (>= (- capacity load) amount)
-                       (not= location nil)))
+                       (= location from)))
                 @trucks)]
-    (when (seq valid-trucks)
+    (if (seq valid-trucks)
       (->> valid-trucks
-           (sort-by (fn [[_ {:keys [location]}]]
-                      (if (= location from) 0
-                                            (count (a-star location from)))))
-           first))))
+           (sort-by (fn [[_ {:keys [load]}]] load))
+           first)
+      (let [nearby-trucks
+            (filter (fn [[tid {:keys [capacity load location]}]]
+                      (and (>= (- capacity load) amount)
+                           (some (fn [[neighbor dist]] (= neighbor location))
+                                 (get graph from))))
+                    @trucks)]
+        (when (seq nearby-trucks)
+          (->> nearby-trucks
+               (sort-by (fn [[tid {:keys [load location]}]]
+                          [(+ load (or (some (fn [[neighbor dist]] (when (= neighbor location) dist))
+                                             (get graph from))
+                                       Integer/MAX_VALUE))
+                           load]))
+               first))))))
 
 ;; ---------------------------------------------------------
 ;; 4. Deliveries with alternative routes


### PR DESCRIPTION
Updated the pick-truck function to prioritize trucks located at the from city.
Added fallback logic to select nearby trucks if no trucks are available at the from city.
Improved sorting criteria to optimize load and minimize travel distances.
Enhanced robustness by explicitly handling cases with no trucks available at or near the from city.