### PR TITLE
Removed unused Java imports for LocalDateTime and DateTimeFormatter.

### DIFF
--- a/ICA2SYC/src/ICA2.clj
+++ b/ICA2SYC/src/ICA2.clj
@@ -1,6 +1,4 @@
-(ns ICA2
-  (:import [java.time LocalDateTime]
-           [java.time.format DateTimeFormatter]))
+(ns ICA2)
 
 ;; ---------------------------------------------------------
 ;; 1. Data about cities, trucks, and daily routes, etc.


### PR DESCRIPTION
This change removes unused imports for Java’s LocalDateTime and DateTimeFormatter, as they are not referenced in the project.